### PR TITLE
feat: indent the output YAML to be compatible with yamllint and prettier

### DIFF
--- a/cmd/tagChanger.go
+++ b/cmd/tagChanger.go
@@ -4,36 +4,37 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/OmerKahani/tagChanger/pkg/github"
 	"github.com/OmerKahani/tagChanger/pkg/yamlChanger"
 	goGithub "github.com/google/go-github/v32/github"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
-	"strings"
 )
 
 var (
-	filePath		string
-	repo			string
-	branch			string
-	user			string
-	pass			string
-	accessToken		string
-	valuePath		string
-	newValue		string
-	commitMessage	string
-	sshFile			string
-	appID			int64
-	installationID	int64
+	filePath       string
+	repo           string
+	branch         string
+	user           string
+	pass           string
+	accessToken    string
+	valuePath      string
+	newValue       string
+	commitMessage  string
+	sshFile        string
+	appID          int64
+	installationID int64
 )
 
-func GetCommand() *cobra.Command{
+func GetCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:	"tagChanger",
-		Short:	"change yaml value in github",
-		Long: 	"changer - retrieve a yaml file from github, change a specific value in it, and commit it back to github",
-		RunE: 	func(_ *cobra.Command, _ []string) error{
+		Use:   "tagChanger",
+		Short: "change yaml value in github",
+		Long:  "changer - retrieve a yaml file from github, change a specific value in it, and commit it back to github",
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			client, err := github.GetClient(user, pass, accessToken, sshFile, appID, installationID, ctx)
@@ -52,18 +53,18 @@ func GetCommand() *cobra.Command{
 	}
 
 	viper.AutomaticEnv()
-	cmd.PersistentFlags().StringVar(&filePath,		"file-path",		"",						"the YAML file path")
-	cmd.PersistentFlags().StringVar(&repo,			"repo",			"", 						"owner/repository")
-	cmd.PersistentFlags().StringVar(&branch,		"branch",			"main",					"The github branch (default is main)")
-	cmd.PersistentFlags().StringVar(&user,			"user",			"", 						"github user")
-	cmd.PersistentFlags().StringVar(&pass,			"pass",			viper.GetString("PASS"),	"github password")
-	cmd.PersistentFlags().StringVar(&accessToken,	"access-token",	viper.GetString("TOKEN"),	"github access token")
-	cmd.PersistentFlags().StringVar(&sshFile,		"ssh-file",		"",						"github ssh key path (.pem file)")
-	cmd.PersistentFlags().Int64Var(&appID,			"app-id",			0,						"the id of the application")
-	cmd.PersistentFlags().Int64Var(&installationID,	"installation-id",0,						"the id of the application installation")
-	cmd.PersistentFlags().StringVar(&valuePath,		"value-path",		"",						"the yaml path to the value")
-	cmd.PersistentFlags().StringVar(&newValue,		"new-value",		"",						"the new value")
-	cmd.PersistentFlags().StringVar(&commitMessage, "commit-msg",		"",						"the commit message that will be used")
+	cmd.PersistentFlags().StringVar(&filePath, "file-path", "", "the YAML file path")
+	cmd.PersistentFlags().StringVar(&repo, "repo", "", "owner/repository")
+	cmd.PersistentFlags().StringVar(&branch, "branch", "main", "The github branch (default is main)")
+	cmd.PersistentFlags().StringVar(&user, "user", "", "github user")
+	cmd.PersistentFlags().StringVar(&pass, "pass", viper.GetString("PASS"), "github password")
+	cmd.PersistentFlags().StringVar(&accessToken, "access-token", viper.GetString("TOKEN"), "github access token")
+	cmd.PersistentFlags().StringVar(&sshFile, "ssh-file", "", "github ssh key path (.pem file)")
+	cmd.PersistentFlags().Int64Var(&appID, "app-id", 0, "the id of the application")
+	cmd.PersistentFlags().Int64Var(&installationID, "installation-id", 0, "the id of the application installation")
+	cmd.PersistentFlags().StringVar(&valuePath, "value-path", "", "the yaml path to the value")
+	cmd.PersistentFlags().StringVar(&newValue, "new-value", "", "the new value")
+	cmd.PersistentFlags().StringVar(&commitMessage, "commit-msg", "", "the commit message that will be used")
 
 	return cmd
 }
@@ -74,7 +75,7 @@ func changeFile(ctx context.Context, client github.RepoService, repo, branch, fi
 		return errors.New("--repo formant should be owner/repository")
 	}
 
-	file, _ , _, err := client.GetContents(ctx, repoSplits[0], repoSplits[1], filePath, &goGithub.RepositoryContentGetOptions{
+	file, _, _, err := client.GetContents(ctx, repoSplits[0], repoSplits[1], filePath, &goGithub.RepositoryContentGetOptions{
 		Ref: branch,
 	})
 	if err != nil {
@@ -104,7 +105,7 @@ func changeFile(ctx context.Context, client github.RepoService, repo, branch, fi
 		return err
 	}
 
-	changedContent, err := yaml.Marshal(&body)
+	changedContent, err := yamlChanger.IndentYaml(&body, 2)
 	if err != nil {
 		return err
 	}
@@ -113,11 +114,11 @@ func changeFile(ctx context.Context, client github.RepoService, repo, branch, fi
 
 	err = AdminForceDisable(ctx, client, repoSplits[0], repoSplits[1], branch,
 		func() error {
-			_,_, err := client.UpdateFile(ctx, repoSplits[0], repoSplits[1], filePath, &goGithub.RepositoryContentFileOptions{
-				Branch:		&branch,
-				Message: 	&commitMessage,
-				Content: 	[]byte(changedContent),
-				SHA:     	goGithub.String(file.GetSHA()),
+			_, _, err := client.UpdateFile(ctx, repoSplits[0], repoSplits[1], filePath, &goGithub.RepositoryContentFileOptions{
+				Branch:  &branch,
+				Message: &commitMessage,
+				Content: []byte(changedContent),
+				SHA:     goGithub.String(file.GetSHA()),
 			})
 
 			return err
@@ -137,15 +138,14 @@ func AdminForceDisable(ctx context.Context, client github.RepoService, owner, re
 		return fn()
 	}
 
-
-	_, err := client.RemoveAdminEnforcement(ctx,owner, repo, branch)
+	_, err := client.RemoveAdminEnforcement(ctx, owner, repo, branch)
 	if err != nil {
 		return err
 	}
 
 	FnErr := fn()
 
-	_, _, err = client.AddAdminEnforcement(ctx,owner, repo, branch)
+	_, _, err = client.AddAdminEnforcement(ctx, owner, repo, branch)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,10 @@ go 1.14
 require (
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/google/go-github/v32 v32.1.0
-	github.com/icza/dyno v0.0.0-20200205103839-49cb13720835
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 // indirect
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
-	gopkg.in/yaml.v2 v2.2.2
-	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/icza/dyno v0.0.0-20200205103839-49cb13720835 h1:f1irK5f03uGGj+FjgQfZ5VhdKNVQVJ4skHsedzVohQ4=
-github.com/icza/dyno v0.0.0-20200205103839-49cb13720835/go.mod h1:c1tRKs5Tx7E2+uHGSyyncziFjvGpgv4H2HrqXeUQ/Uk=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -166,8 +164,6 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
-gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/yamlChanger/yamlChanger.go
+++ b/pkg/yamlChanger/yamlChanger.go
@@ -1,10 +1,12 @@
 package yamlChanger
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 type PathError struct {
@@ -13,7 +15,6 @@ type PathError struct {
 func (p *PathError) Error() string {
 	return fmt.Sprintf("valuePath or part of it is empty")
 }
-
 
 func GetPathSplits(path string) (res []string, err error) {
 	splits := strings.Split(path, ".")
@@ -31,10 +32,10 @@ func GetPathSplits(path string) (res []string, err error) {
 
 }
 
-func findNodeValue(node *yaml.Node, path []string) *yaml.Node{
+func findNodeValue(node *yaml.Node, path []string) *yaml.Node {
 
 	found := false
-	for _, n := range node.Content{
+	for _, n := range node.Content {
 		if found == true {
 			if len(path) == 1 {
 				return n
@@ -62,4 +63,16 @@ func ChangeYaml(body *yaml.Node, newValue string, path []string) error {
 	node.Value = fmt.Sprintf("%s", newValue)
 
 	return nil
+}
+
+func IndentYaml(body *yaml.Node, indent int) ([]byte, error) {
+	var b bytes.Buffer
+	yamlEncoder := yaml.NewEncoder(&b)
+	yamlEncoder.SetIndent(indent)
+	err := yamlEncoder.Encode(&body)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
 }


### PR DESCRIPTION
The YAML created from the tool is not indented correctly.
It defaults to 4, but also fails with files like this one: https://github.com/snyk/infra-polaris-manifest/blob/main/values/cloud-platforms.yaml#L19-L26
```shell
24:17     error    wrong indentation: expected 18 but found 16  (indentation)
26:17     error    wrong indentation: expected 18 but found 16  (indentation)
```

This makes the tool not compatible with the linters we want to enforce in our repos (yamllint, prettier).

The PR fixes it. I tested the code in isolation from another Go app. It would be nice to test it here, but I don't know how to do it.

